### PR TITLE
feat (or fix?): Handle deleted users

### DIFF
--- a/src/Classes/Parsing/DUser.cs
+++ b/src/Classes/Parsing/DUser.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Data_Package_Tool.Helpers;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Media.Imaging;
@@ -36,6 +37,11 @@ namespace Data_Package_Tool.Classes.Parsing
         public bool IsPomelo()
         {
             return this.discriminator == "0" || this.discriminator == "0000";
+        }
+
+        public bool IsDeletedUser()
+        {
+            return this.id == Consts.DeletedUserId;
         }
 
         public string GetTag()

--- a/src/Forms/DmWPF.xaml.cs
+++ b/src/Forms/DmWPF.xaml.cs
@@ -231,6 +231,10 @@ namespace Data_Package_Tool.Forms
                         }
                     }
 
+                    // Save the user id in settings for reuse
+                    Properties.Settings.Default.ResolvedDeletedUsers.AddRange(new string[] {this.ChannelId, recipient.id});
+                    Properties.Settings.Default.Save();
+
                     DataContext.UnknownId = false;
                 }
             }

--- a/src/Forms/DmWPF.xaml.cs
+++ b/src/Forms/DmWPF.xaml.cs
@@ -125,7 +125,7 @@ namespace Data_Package_Tool.Forms
             }
             if (!Discord.ValidateToken(Discord.UserToken, Main.DataPackage.User.id))
             {
-                Util.MsgBoxErr(Consts.InvalidBotTokenError);
+                Util.MsgBoxErr(Consts.InvalidTokenError);
                 return null;
             }
 

--- a/src/Forms/DmWPF.xaml.cs
+++ b/src/Forms/DmWPF.xaml.cs
@@ -100,39 +100,104 @@ namespace Data_Package_Tool.Forms
         public static readonly DependencyProperty NeedsFetchingProperty =
             DependencyProperty.Register("NeedsFetching", typeof(bool), typeof(DmWPF));
 
+        public bool UnknownId
+        {
+            get { return (bool)GetValue(UnknownIdProperty); }
+            set { SetValue(UnknownIdProperty, value); }
+        }
+
+        public static readonly DependencyProperty UnknownIdProperty =
+            DependencyProperty.Register("UnknownId", typeof(bool), typeof(DmWPF));
+
+
+
         public DmWPF()
         {
             InitializeComponent();
         }
 
-        private async void fetchBtn_Click(object sender, RoutedEventArgs e)
+        private async Task<DUser> FetchUserFromChannel(string channelId)
         {
-            if(Discord.BotToken == null)
+            if (Discord.UserToken == null)
             {
-                Util.MsgBoxErr(Consts.MissingBotTokenError);
-                return;
+                Util.MsgBoxErr(Consts.MissingTokenError);
+                return null;
             }
-            if(!Discord.ValidateToken(Discord.BotToken))
+            if (!Discord.ValidateToken(Discord.UserToken, Main.DataPackage.User.id))
             {
                 Util.MsgBoxErr(Consts.InvalidBotTokenError);
-                return;
-            }
-            if(Discord.ValidateToken(Discord.BotToken, Main.DataPackage.User.id))
-            {
-                Util.MsgBoxErr(Consts.WrongTokenType);
-                return;
+                return null;
             }
 
-            var res = await DRequest.RequestAsync(HttpMethod.Get, $"https://discord.com/api/v9/users/{this.UserId}", new Dictionary<string, string>
+            await DHeaders.Init();
+
+            var res = await DRequest.RequestAsync(HttpMethod.Get, $"https://discord.com/api/v9/channels/{channelId}", new Dictionary<string, string>
+            {
+                {"Authorization", Discord.UserToken}
+            });
+
+            if (res.response.StatusCode == System.Net.HttpStatusCode.OK)
+            {
+                DUser recipient = Newtonsoft.Json.JsonConvert.DeserializeObject<dynamic>(res.body).recipients[0].ToObject<DUser>();
+                return recipient;
+            }
+            else
+            {
+                Util.MsgBoxErr($"Status code {res.response.StatusCode} - {res.body}");
+                return null;
+            }
+        }
+
+        private async Task<DUser> FetchUserFromLookup(string userId)
+        {
+            if (Discord.BotToken == null)
+            {
+                Util.MsgBoxErr(Consts.MissingBotTokenError);
+                return null;
+            }
+            if (!Discord.ValidateToken(Discord.BotToken))
+            {
+                Util.MsgBoxErr(Consts.InvalidBotTokenError);
+                return null;
+            }
+            if (Discord.ValidateToken(Discord.BotToken, Main.DataPackage.User.id))
+            {
+                Util.MsgBoxErr(Consts.WrongTokenType);
+                return null;
+            }
+
+            var res = await DRequest.RequestAsync(HttpMethod.Get, $"https://discord.com/api/v9/users/{userId}", new Dictionary<string, string>
             {
                 {"Authorization", $"Bot {Discord.BotToken}"}
             }, null, false);
 
-            if(res.response.StatusCode == System.Net.HttpStatusCode.OK)
+            if (res.response.StatusCode == System.Net.HttpStatusCode.OK)
             {
-                DmsListEntry DataContext = this.DataContext as DmsListEntry;
                 DUser recipient = Newtonsoft.Json.JsonConvert.DeserializeObject<DUser>(res.body);
+                return recipient;
+            } else
+            {
+                Util.MsgBoxErr($"Status code {res.response.StatusCode} - {res.body}");
+                return null;
+            }
+        }
 
+        private async void fetchBtn_Click(object sender, RoutedEventArgs e)
+        {
+            DmsListEntry DataContext = this.DataContext as DmsListEntry;
+            DUser recipient;
+               
+            if(this.UnknownId)
+            {
+                recipient = await FetchUserFromChannel(this.ChannelId);
+            } else
+            {
+                recipient = await FetchUserFromLookup(this.UserId);
+            }
+
+            if (recipient != null)
+            {
+                DataContext.UserId = recipient.id;
                 DataContext.Username = recipient.GetTag();
                 if (recipient.avatar != null)
                 {
@@ -145,14 +210,40 @@ namespace Data_Package_Tool.Forms
                     DataContext.Avatar = avatar;
                 }
                 DataContext.NeedsFetching = false;
-            } else
-            {
-                Util.MsgBoxErr($"Status code {res.response.StatusCode} - {res.body}");
+
+                // Now that we know the id, do what we couldn't do before
+                if(this.UnknownId)
+                {
+                    // Check if there's a note
+                    DataContext.Note = Main.DataPackage.User.notes.ContainsKey(recipient.id) ? Main.DataPackage.User.notes[recipient.id] : "";
+
+                    // Perform the duplicate channels check
+                    var dmChannels = Main.DataPackage.Channels.Where(x => x.IsDM()).OrderByDescending(o => Int64.Parse(o.id)).ToList();
+                    foreach (var dmChannel in dmChannels)
+                    {
+                        if (dmChannel.id == this.ChannelId) continue; // Don't count self as a duplicate
+
+                        string recipientId = dmChannel.GetOtherDMRecipient(Main.DataPackage.User);
+                        if(recipientId == this.UserId)
+                        {
+                            dmChannel.has_duplicates = true;
+                            Main.DataPackage.ChannelsMap[this.ChannelId].has_duplicates = true;
+                        }
+                    }
+
+                    DataContext.UnknownId = false;
+                }
             }
         }
 
         private async void openDmBtn_Click(object sender, RoutedEventArgs e)
         {
+            if(this.UnknownId)
+            {
+                Util.MsgBoxErr(Consts.UnknownDeletedUserId);
+                return;
+            }
+
             if (Main.DataPackage.ChannelsMap[this.ChannelId].has_duplicates)
             {
                 Util.MsgBoxWarn(Consts.DuplicateDMWarning);
@@ -166,6 +257,12 @@ namespace Data_Package_Tool.Forms
 
         private void copyUserIdMi_Click(object sender, RoutedEventArgs e)
         {
+            if (this.UnknownId)
+            {
+                Util.MsgBoxErr(Consts.UnknownDeletedUserId);
+                return;
+            }
+
             Clipboard.SetText(this.UserId);
         }
 

--- a/src/Forms/DmsListWPF.xaml
+++ b/src/Forms/DmsListWPF.xaml
@@ -64,7 +64,8 @@
                                  Avatar="{Binding Avatar}"
                                  MessagesCount="{Binding MessagesCount}"
                                  Note="{Binding Note}"
-                                 NeedsFetching="{Binding NeedsFetching}"/>
+                                 NeedsFetching="{Binding NeedsFetching}"
+                                 UnknownId="{Binding UnknownId}"/>
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>

--- a/src/Forms/DmsListWPF.xaml.cs
+++ b/src/Forms/DmsListWPF.xaml.cs
@@ -34,18 +34,30 @@ namespace Data_Package_Tool.Forms
             {
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
             }
-            public string UserId { get; set; }
+            private string UserIdValue;
+            public string UserId
+            {
+                get
+                {
+                    return this.UserIdValue;
+                }
+                set
+                {
+                    this.UserIdValue = value;
+                    NotifyPropertyChanged();
+                }
+            }
             public string ChannelId { get; set; }
-            private string UsernameVal;
+            private string UsernameValue;
             public string Username
             {
                 get
                 {
-                    return this.UsernameVal;
+                    return this.UsernameValue;
                 }
                 set
                 {
-                    this.UsernameVal = value;
+                    this.UsernameValue = value;
                     NotifyPropertyChanged();
                 }
             }
@@ -64,7 +76,19 @@ namespace Data_Package_Tool.Forms
             }
             public string Date { get; set; }
             public int MessagesCount { get; set; }
-            public string Note { get; set; }
+            private string NoteValue;
+            public string Note
+            {
+                get
+                {
+                    return this.NoteValue;
+                }
+                set
+                {
+                    this.NoteValue = value;
+                    NotifyPropertyChanged();
+                }
+            }
             private bool NeedsFetchingValue;
             public bool NeedsFetching
             {
@@ -75,6 +99,19 @@ namespace Data_Package_Tool.Forms
                 set
                 {
                     this.NeedsFetchingValue = value;
+                    NotifyPropertyChanged();
+                }
+            }
+            private bool UnknownIdValue;
+            public bool UnknownId
+            {
+                get
+                {
+                    return this.UnknownIdValue;
+                }
+                set
+                {
+                    this.UnknownIdValue = value;
                     NotifyPropertyChanged();
                 }
             }
@@ -107,16 +144,19 @@ namespace Data_Package_Tool.Forms
                     avatar = new DUser() { id = recipientId, discriminator = "0" }.GetDefaultAvatarBitmapImage();
                 }
 
+                bool isDeletedUser = recipientId == Consts.DeletedUserId;
+
                 DirectMessages.Add(new DmsListEntry
                 { 
-                    UserId = recipientId,
+                    UserId = isDeletedUser ? "???" : recipientId,
                     ChannelId = channel.id,
-                    Username = relationship != null ? relationship.user.GetTag() : "(Unknown User)",
+                    Username = isDeletedUser ? "(Deleted User)" : relationship != null ? relationship.user.GetTag() : "(Unknown User)",
                     Avatar = avatar,
                     Date = Discord.SnowflakeToTimestap(channel.id).ToShortDateString(),
                     MessagesCount = channel.messages.Count,
                     Note = user.notes.ContainsKey(recipientId) ? user.notes[recipientId] : "",
-                    NeedsFetching = relationship == null
+                    NeedsFetching = relationship == null,
+                    UnknownId = isDeletedUser
                 });
             }
         }

--- a/src/Forms/DmsListWPF.xaml.cs
+++ b/src/Forms/DmsListWPF.xaml.cs
@@ -146,6 +146,17 @@ namespace Data_Package_Tool.Forms
 
                 bool isDeletedUser = recipientId == Consts.DeletedUserId;
 
+                // Get saved id, if exists
+                if (isDeletedUser)
+                {
+                    int idx = Properties.Settings.Default.ResolvedDeletedUsers.IndexOf(channel.id);
+                    if(idx != -1)
+                    {
+                        recipientId = Properties.Settings.Default.ResolvedDeletedUsers[idx + 1];
+                        isDeletedUser = false;
+                    }
+                }
+
                 DirectMessages.Add(new DmsListEntry
                 { 
                     UserId = isDeletedUser ? "???" : recipientId,

--- a/src/Forms/MessageWPF.xaml
+++ b/src/Forms/MessageWPF.xaml
@@ -19,6 +19,7 @@
             <MenuItem x:Name="viewInGuildsTab" Header="View server in Servers tab" IsEnabled="False" Click="viewInGuildsTab_Click"/>
             <Separator/>
             <MenuItem x:Name="deleteMessageMi" Header="Delete message (SELFBOT)" Click="deleteMessageMi_Click"/>
+            <MenuItem x:Name="fetchInfoMi" Header="Fetch info (SELFBOT)" Visibility="Collapsed" Click="fetchInfoMi_Click"/>
         </ContextMenu>
     </UserControl.ContextMenu>
     <Grid x:Name="rootGrid" Background="#00000000" MouseEnter="Grid_MouseEnter" MouseLeave="Grid_MouseLeave">

--- a/src/Forms/MessageWPF.xaml.cs
+++ b/src/Forms/MessageWPF.xaml.cs
@@ -148,6 +148,15 @@ namespace Data_Package_Tool
                         id = recipientId
                     };
                 }
+
+                if(this.Recipient.IsDeletedUser())
+                {
+                    int idx = Properties.Settings.Default.ResolvedDeletedUsers.IndexOf(message.channel.id);
+                    if(idx != -1)
+                    {
+                        this.Recipient.id = Properties.Settings.Default.ResolvedDeletedUsers[idx + 1];
+                    }
+                }
             }
 
             // Set username

--- a/src/Forms/MessageWPF.xaml.cs
+++ b/src/Forms/MessageWPF.xaml.cs
@@ -591,13 +591,16 @@ namespace Data_Package_Tool
                 {"Authorization", Discord.UserToken}
             });
 
-            if (res.response.StatusCode == System.Net.HttpStatusCode.OK)
+            if (res.response.StatusCode == HttpStatusCode.OK)
             {
                 DUser recipient = Newtonsoft.Json.JsonConvert.DeserializeObject<dynamic>(res.body).recipients[0].ToObject<DUser>();
                 this.Recipient = recipient;
                 UpdateMetadata();
 
-                // TODO: also save in settings and change data in the appropriate dmlist entry (make a single function to do that?)
+                Properties.Settings.Default.ResolvedDeletedUsers.AddRange(new string[] { this.Message.channel.id, recipient.id });
+                Properties.Settings.Default.Save();
+
+                // TODO: also change data in the appropriate dmlist entry
             }
             else
             {

--- a/src/Forms/MessageWPF.xaml.cs
+++ b/src/Forms/MessageWPF.xaml.cs
@@ -87,6 +87,11 @@ namespace Data_Package_Tool
                 {
                     metadata += $"DMs with {this.Recipient.GetTag()}";
                 }
+
+                else if (this.Recipient.IsDeletedUser())
+                {
+                    metadata += $"DMs with Unknown Deleted User (channel {channel.id})";
+                }
                 else
                 {
                     metadata += $"DMs with {this.Recipient.id}";

--- a/src/Helpers/Consts.cs
+++ b/src/Helpers/Consts.cs
@@ -8,5 +8,7 @@
         public static readonly string MissingBotTokenError = "You must enter a bot token in the Settings tab to use this function.";
         public static readonly string InvalidBotTokenError = "Entered token is invalid!";
         public static readonly string WrongTokenType = "Entered bot token belongs to your own account!";
+
+        public static readonly string DeletedUserId = "456226577798135808";
     }
 }

--- a/src/Helpers/Consts.cs
+++ b/src/Helpers/Consts.cs
@@ -8,6 +8,7 @@
         public static readonly string MissingBotTokenError = "You must enter a bot token in the Settings tab to use this function.";
         public static readonly string InvalidBotTokenError = "Entered token is invalid!";
         public static readonly string WrongTokenType = "Entered bot token belongs to your own account!";
+        public static readonly string UnknownDeletedUserId = "The user id of this deleted user is unknown. Use Fetch Info first.";
 
         public static readonly string DeletedUserId = "456226577798135808";
     }

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -114,6 +114,8 @@ namespace Data_Package_Tool
             foreach (var dmChannel in dmChannels)
             {
                 string recipientId = dmChannel.GetOtherDMRecipient(DataPackage.User);
+                if (recipientId == Consts.DeletedUserId) continue; // Don't mark the fake deleted user id as duplicate
+
                 if (duplicateChannelsMap.ContainsKey(recipientId)) // Optimization. Calling Find() every time would be slow
                 {
                     duplicateChannelsMap[recipientId].has_duplicates = true;

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -75,6 +75,12 @@ namespace Data_Package_Tool
                 Properties.Settings.Default.DeletedMessageIDs = new System.Collections.Specialized.StringCollection();
                 Properties.Settings.Default.Save();
             }
+            
+            if(Properties.Settings.Default.ResolvedDeletedUsers == null)
+            {
+                Properties.Settings.Default.ResolvedDeletedUsers = new System.Collections.Specialized.StringCollection();
+                Properties.Settings.Default.Save();
+            }
 
             switch (Properties.Settings.Default.UseDiscordInstance)
             {

--- a/src/Properties/Settings.Designer.cs
+++ b/src/Properties/Settings.Designer.cs
@@ -223,5 +223,16 @@ namespace Data_Package_Tool.Properties {
                 this["SearchHasVideo"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        public global::System.Collections.Specialized.StringCollection ResolvedDeletedUsers {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["ResolvedDeletedUsers"]));
+            }
+            set {
+                this["ResolvedDeletedUsers"] = value;
+            }
+        }
     }
 }

--- a/src/Properties/Settings.settings
+++ b/src/Properties/Settings.settings
@@ -53,5 +53,8 @@
     <Setting Name="SearchHasVideo" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="ResolvedDeletedUsers" Type="System.Collections.Specialized.StringCollection" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
This adds support for Discord's recent change to the data package which anonymizes user ids of deleted users in the `recipients` channel field.