### PR TITLE
feat: Refresh attachment urls

### DIFF
--- a/src/Classes/DataPackage.cs
+++ b/src/Classes/DataPackage.cs
@@ -37,10 +37,7 @@ namespace Data_Package_Tool.Classes
         public DateTime CreationTime { get; private set; }
         public int TotalMessages { get; private set; } = 0;
 
-        public bool UsesUnsignedCDNLinks
-        {
-            get => ImageAttachments.Count > 0 && !ImageAttachments[0].Url.Contains("?ex=");
-        }
+        public bool UsesUnsignedCDNLinks { get; private set; }
 
         public LoadStatus LoadStatus = new()
         {
@@ -209,6 +206,7 @@ namespace Data_Package_Tool.Classes
             });
 
             this.ImageAttachments = this.ImageAttachments.OrderByDescending(o => Int64.Parse(o.Message.Id)).ToList();
+            this.UsesUnsignedCDNLinks = ImageAttachments.Count > 0 && !ImageAttachments[0].IsSigned;
             this.LoadStatus.Status = $"Finished! Parsed {this.TotalMessages.ToString("N0", new NumberFormatInfo { NumberGroupSeparator = " " })} messages in {Math.Floor((DateTime.Now - startTime).TotalSeconds)}s\nPackage created at: {this.CreationTime.ToShortDateString()}";
 
             this.LoadStatus.Finished = true;

--- a/src/Classes/Parsing/DAttachment.cs
+++ b/src/Classes/Parsing/DAttachment.cs
@@ -24,11 +24,20 @@ namespace Data_Package_Tool.Classes.Parsing
         {
             get => VideoExtensions.Contains(this.Extension);
         }
+        public bool IsSigned
+        {
+            get => Url.Contains("?ex=");
+        }
 
         public DAttachment(string url, DMessage message)
         {
-            this.Url = url;
             this.Message = message;
+            this.UpdateUrl(url);
+        }
+
+        public void UpdateUrl(string url)
+        {
+            this.Url = url;
 
             var match = Regex.Match(url, @"attachments\/\d+\/(\d+)\/([\w.-]+\.(\w+))");
             this.Id = match.Groups[1].Value;

--- a/src/Forms/MessageListWPF.xaml.cs
+++ b/src/Forms/MessageListWPF.xaml.cs
@@ -24,14 +24,14 @@ namespace Data_Package_Tool
             Messages.Clear();
         }
 
-        public void DisplayMessages(List<DMessage> messages, int startIdx, int endIdx)
+        public void DisplayMessages(List<DMessage> messages)
         {
-            for(int i=startIdx;i<=endIdx;i++)
+            foreach(var msg in messages)
             {
-                Messages.Add(messages[i]);
+                Messages.Add(msg);
             }
 
-            mainList.ScrollIntoView(messages[startIdx]);
+            mainList.ScrollIntoView(messages[0]);
         }
     }
 }

--- a/src/Helpers/Consts.cs
+++ b/src/Helpers/Consts.cs
@@ -3,10 +3,10 @@
     public class Consts
     {
         public static readonly string DuplicateDMWarning = "You have multiple dm channels with this user! This is likely due to a bug which allowed opening multiple dms when messaging someone for the first time.\n\nSince Discord only saves a single dm channel as the default dm, there is no guarantee that it will open the right one.";
-        public static readonly string InvalidTokenError = "Entered token is invalid or doesn't belong to the same account!";
+        public static readonly string InvalidTokenError = "Entered user token is invalid or doesn't belong to the same account!";
         public static readonly string MissingTokenError = "You must enter your account token in the Settings tab to use this function.";
         public static readonly string MissingBotTokenError = "You must enter a bot token in the Settings tab to use this function.";
-        public static readonly string InvalidBotTokenError = "Entered token is invalid!";
+        public static readonly string InvalidBotTokenError = "Entered bot token is invalid!";
         public static readonly string WrongTokenType = "Entered bot token belongs to your own account!";
         public static readonly string UnknownDeletedUserId = "The user id of this deleted user is unknown. Use Fetch Info first.";
 

--- a/src/Helpers/Discord.cs
+++ b/src/Helpers/Discord.cs
@@ -318,6 +318,7 @@ namespace Data_Package_Tool.Classes
             } catch(Exception ex)
             {
                 Util.MsgBoxErr($"Failed to refresh attachments: {ex}");
+                return false;
             }
 
             return true;

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -172,6 +172,15 @@ namespace Data_Package_Tool
             Util.MsgBoxErr("Server could not be found in your joined servers list (bug?)");
         }
 
+        private void ToggleSearchOptions(bool enabled)
+        {
+            searchBtn.Enabled = enabled;
+            searchTb.Enabled = enabled;
+            searchOptionsBtn.Enabled = enabled;
+            messagesPrevBtn.Enabled = enabled;
+            messagesNextBtn.Enabled = enabled;
+        }
+
         private void loadFileBtn_Click(object sender, EventArgs e)
         {
             if (openFileDialog1.ShowDialog() == DialogResult.OK)
@@ -255,11 +264,7 @@ namespace Data_Package_Tool
         {
             if (LastSearchResults == null || LastSearchResults.Count == 0) return;
 
-            searchBtn.Enabled = false;
-            searchTb.Enabled = false;
-            searchOptionsBtn.Enabled = false;
-            messagesPrevBtn.Enabled = false;
-            messagesNextBtn.Enabled = false;
+            ToggleSearchOptions(false);
 
             // Clear images cache to free up RAM
             Discord.AttachmentsCache.Clear();
@@ -293,11 +298,7 @@ namespace Data_Package_Tool
             ((MessageListWPF)elementHost1.Child).DisplayMessages(msgsToShow);
             resultsCountLb.Text = $"{SearchResultsOffset + 1}-{Math.Min(SearchResultsOffset + MaxSearchResults, LastSearchResults.Count)} of {LastSearchResults.Count}";
 
-            searchBtn.Enabled = true;
-            searchTb.Enabled = true;
-            searchOptionsBtn.Enabled = true;
-            messagesPrevBtn.Enabled = true;
-            messagesNextBtn.Enabled = true;
+            ToggleSearchOptions(true);
         }
         private void searchBtn_Click(object sender, EventArgs e)
         {
@@ -314,11 +315,7 @@ namespace Data_Package_Tool
                 }
             }
 
-            searchBtn.Enabled = false;
-            searchTb.Enabled = false;
-            searchOptionsBtn.Enabled = false;
-            messagesPrevBtn.Enabled = false;
-            messagesNextBtn.Enabled = false;
+            ToggleSearchOptions(false);
             ((MessageListWPF)elementHost1.Child).Clear();
 
             LastSearchResults = new List<DMessage>();

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -1,4 +1,4 @@
-using Data_Package_Tool.Classes;
+﻿using Data_Package_Tool.Classes;
 using Data_Package_Tool.Classes.Parsing;
 using Data_Package_Tool.Forms;
 using Data_Package_Tool.Helpers;
@@ -214,7 +214,7 @@ namespace Data_Package_Tool
 
                     if (DataPackage.UsesUnsignedCDNLinks)
                     {
-                        Util.MsgBoxWarn("This data package was created before Discord's attachment url signing.\nImages may be broken, and other attachments may be inaccessible!");
+                        Util.MsgBoxWarn("This data package was created before Discord's attachment url signing!\n\nIf you want to be able to view images and other attachments, please enter a bot token in the settings tab.");
                     }
                 }, TaskScheduler.FromCurrentSynchronizationContext());
 


### PR DESCRIPTION
This makes the tool fully usable on older data packages by automatically refreshing attachment urls if a bot token is provided.