### PR TITLE
feat: image tab date/time filter

### DIFF
--- a/src/Main.Designer.cs
+++ b/src/Main.Designer.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace Data_Package_Tool
 {
     partial class Main
@@ -50,6 +50,10 @@ namespace Data_Package_Tool
             imagesCountLb = new System.Windows.Forms.Label();
             imagesNextBtn = new System.Windows.Forms.Button();
             imagesPrevBtn = new System.Windows.Forms.Button();
+            imagesAfterCb = new System.Windows.Forms.CheckBox();
+            imagesAfterDtp = new System.Windows.Forms.DateTimePicker();
+            imagesBeforeCb = new System.Windows.Forms.CheckBox();
+            imagesBeforeDtp = new System.Windows.Forms.DateTimePicker();
             serversTab = new System.Windows.Forms.TabPage();
             serversStatusStrip = new System.Windows.Forms.StatusStrip();
             serversStatusLb = new System.Windows.Forms.ToolStripStatusLabel();
@@ -276,6 +280,10 @@ namespace Data_Package_Tool
             // 
             imagesTab.BackColor = System.Drawing.Color.FromArgb(49, 51, 56);
             imagesTab.Controls.Add(imagesPanel);
+            imagesTab.Controls.Add(imagesBeforeDtp);
+            imagesTab.Controls.Add(imagesBeforeCb);
+            imagesTab.Controls.Add(imagesAfterDtp);
+            imagesTab.Controls.Add(imagesAfterCb);
             imagesTab.Controls.Add(imagesCountLb);
             imagesTab.Controls.Add(imagesNextBtn);
             imagesTab.Controls.Add(imagesPrevBtn);
@@ -328,6 +336,50 @@ namespace Data_Package_Tool
             imagesPrevBtn.Text = "<";
             imagesPrevBtn.UseVisualStyleBackColor = true;
             imagesPrevBtn.Click += imagesPrevBtn_Click;
+            // 
+            // imagesAfterCb
+            // 
+            imagesAfterCb.AutoSize = true;
+            imagesAfterCb.ForeColor = System.Drawing.SystemColors.Control;
+            imagesAfterCb.Location = new System.Drawing.Point(200, 10);
+            imagesAfterCb.Name = "imagesAfterCb";
+            imagesAfterCb.Size = new System.Drawing.Size(52, 19);
+            imagesAfterCb.TabIndex = 4;
+            imagesAfterCb.Text = "After";
+            imagesAfterCb.UseVisualStyleBackColor = true;
+            imagesAfterCb.CheckedChanged += imagesDateFilter_CheckedChanged;
+            // 
+            // imagesAfterDtp
+            // 
+            imagesAfterDtp.Enabled = false;
+            imagesAfterDtp.Format = System.Windows.Forms.DateTimePickerFormat.Short;
+            imagesAfterDtp.Location = new System.Drawing.Point(255, 7);
+            imagesAfterDtp.Name = "imagesAfterDtp";
+            imagesAfterDtp.Size = new System.Drawing.Size(100, 23);
+            imagesAfterDtp.TabIndex = 5;
+            imagesAfterDtp.ValueChanged += imagesDateFilter_ValueChanged;
+            // 
+            // imagesBeforeCb
+            // 
+            imagesBeforeCb.AutoSize = true;
+            imagesBeforeCb.ForeColor = System.Drawing.SystemColors.Control;
+            imagesBeforeCb.Location = new System.Drawing.Point(365, 10);
+            imagesBeforeCb.Name = "imagesBeforeCb";
+            imagesBeforeCb.Size = new System.Drawing.Size(58, 19);
+            imagesBeforeCb.TabIndex = 6;
+            imagesBeforeCb.Text = "Before";
+            imagesBeforeCb.UseVisualStyleBackColor = true;
+            imagesBeforeCb.CheckedChanged += imagesDateFilter_CheckedChanged;
+            // 
+            // imagesBeforeDtp
+            // 
+            imagesBeforeDtp.Enabled = false;
+            imagesBeforeDtp.Format = System.Windows.Forms.DateTimePickerFormat.Short;
+            imagesBeforeDtp.Location = new System.Drawing.Point(425, 7);
+            imagesBeforeDtp.Name = "imagesBeforeDtp";
+            imagesBeforeDtp.Size = new System.Drawing.Size(100, 23);
+            imagesBeforeDtp.TabIndex = 7;
+            imagesBeforeDtp.ValueChanged += imagesDateFilter_ValueChanged;
             // 
             // serversTab
             // 
@@ -733,6 +785,10 @@ namespace Data_Package_Tool
         private System.Windows.Forms.Button imagesPrevBtn;
         private System.Windows.Forms.Label imagesCountLb;
         private System.Windows.Forms.Panel imagesPanel;
+        private System.Windows.Forms.CheckBox imagesAfterCb;
+        private System.Windows.Forms.DateTimePicker imagesAfterDtp;
+        private System.Windows.Forms.CheckBox imagesBeforeCb;
+        private System.Windows.Forms.DateTimePicker imagesBeforeDtp;
         private System.Windows.Forms.TabPage settingsTab;
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.RadioButton canaryRb;

--- a/src/Main.Designer.cs
+++ b/src/Main.Designer.cs
@@ -351,19 +351,21 @@ namespace Data_Package_Tool
             // 
             // imagesAfterDtp
             // 
+            imagesAfterDtp.CustomFormat = "MM/dd/yyyy HH:mm:ss";
             imagesAfterDtp.Enabled = false;
-            imagesAfterDtp.Format = System.Windows.Forms.DateTimePickerFormat.Short;
+            imagesAfterDtp.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
             imagesAfterDtp.Location = new System.Drawing.Point(255, 7);
             imagesAfterDtp.Name = "imagesAfterDtp";
-            imagesAfterDtp.Size = new System.Drawing.Size(100, 23);
+            imagesAfterDtp.Size = new System.Drawing.Size(200, 23);
             imagesAfterDtp.TabIndex = 5;
+            imagesAfterDtp.Value = new System.DateTime(2023, 1, 1, 0, 0, 0, 0);
             imagesAfterDtp.ValueChanged += imagesDateFilter_ValueChanged;
             // 
             // imagesBeforeCb
             // 
             imagesBeforeCb.AutoSize = true;
             imagesBeforeCb.ForeColor = System.Drawing.SystemColors.Control;
-            imagesBeforeCb.Location = new System.Drawing.Point(365, 10);
+            imagesBeforeCb.Location = new System.Drawing.Point(465, 10);
             imagesBeforeCb.Name = "imagesBeforeCb";
             imagesBeforeCb.Size = new System.Drawing.Size(58, 19);
             imagesBeforeCb.TabIndex = 6;
@@ -373,11 +375,12 @@ namespace Data_Package_Tool
             // 
             // imagesBeforeDtp
             // 
+            imagesBeforeDtp.CustomFormat = "MM/dd/yyyy HH:mm:ss";
             imagesBeforeDtp.Enabled = false;
-            imagesBeforeDtp.Format = System.Windows.Forms.DateTimePickerFormat.Short;
-            imagesBeforeDtp.Location = new System.Drawing.Point(425, 7);
+            imagesBeforeDtp.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
+            imagesBeforeDtp.Location = new System.Drawing.Point(525, 7);
             imagesBeforeDtp.Name = "imagesBeforeDtp";
-            imagesBeforeDtp.Size = new System.Drawing.Size(100, 23);
+            imagesBeforeDtp.Size = new System.Drawing.Size(200, 23);
             imagesBeforeDtp.TabIndex = 7;
             imagesBeforeDtp.ValueChanged += imagesDateFilter_ValueChanged;
             // 

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -577,9 +577,9 @@ namespace Data_Package_Tool
         {
             IEnumerable<DAttachment> imgs = DataPackage.ImageAttachments;
             if (imagesAfterCb.Checked)
-                imgs = imgs.Where(a => a.Message.Timestamp > imagesAfterDtp.Value.Date);
+                imgs = imgs.Where(a => a.Message.Timestamp > imagesAfterDtp.Value);
             if (imagesBeforeCb.Checked)
-                imgs = imgs.Where(a => a.Message.Timestamp < imagesBeforeDtp.Value.Date.AddDays(1));
+                imgs = imgs.Where(a => a.Message.Timestamp < imagesBeforeDtp.Value);
             return imgs.ToList();
         }
 

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -1,4 +1,4 @@
-﻿using Data_Package_Tool.Classes;
+using Data_Package_Tool.Classes;
 using Data_Package_Tool.Classes.Parsing;
 using Data_Package_Tool.Forms;
 using Data_Package_Tool.Helpers;
@@ -571,11 +571,27 @@ namespace Data_Package_Tool
         private int imagesPerPage = 36;
         private int imagesPerRow = 9;
         private int imageSquareSize = 200;
+        private List<DAttachment> filteredImageAttachments;
+
+        private List<DAttachment> GetFilteredImages()
+        {
+            IEnumerable<DAttachment> imgs = DataPackage.ImageAttachments;
+            if (imagesAfterCb.Checked)
+                imgs = imgs.Where(a => a.Message.Timestamp > imagesAfterDtp.Value.Date);
+            if (imagesBeforeCb.Checked)
+                imgs = imgs.Where(a => a.Message.Timestamp < imagesBeforeDtp.Value.Date.AddDays(1));
+            return imgs.ToList();
+        }
+
         private async Task LoadImages()
         {
-            if (DataPackage.ImageAttachments.Count == 0)
+            if (filteredImageAttachments == null)
+                filteredImageAttachments = GetFilteredImages();
+
+            if (filteredImageAttachments.Count == 0)
             {
                 imagesCountLb.Text = $"No images found";
+                imagesPanel.Controls.Clear();
                 return;
             }
 
@@ -583,7 +599,7 @@ namespace Data_Package_Tool
             imagesPrevBtn.Enabled = false;
 
             if (imagesOffset < 0) imagesOffset = 0;
-            if (imagesOffset >= DataPackage.ImageAttachments.Count || imagesOffset + imagesPerPage >= DataPackage.ImageAttachments.Count) imagesOffset = DataPackage.ImageAttachments.Count - imagesPerPage;
+            if (imagesOffset >= filteredImageAttachments.Count || imagesOffset + imagesPerPage >= filteredImageAttachments.Count) imagesOffset = filteredImageAttachments.Count - imagesPerPage;
 
             // Refresh images on the current page
             if (DataPackage.UsesUnsignedCDNLinks)
@@ -591,7 +607,7 @@ namespace Data_Package_Tool
                 var needRefreshing = new List<DAttachment>();
                 for (int i = 0; i < imagesPerPage; i++)
                 {
-                    var attachment = DataPackage.ImageAttachments[imagesOffset + i];
+                    var attachment = filteredImageAttachments[imagesOffset + i];
                     if (!attachment.IsSigned)
                     {
                         needRefreshing.Add(attachment);
@@ -606,7 +622,7 @@ namespace Data_Package_Tool
             }
 
             imagesPanel.Controls.Clear();
-            imagesCountLb.Text = $"{imagesOffset + 1}-{imagesOffset + imagesPerPage} of {DataPackage.ImageAttachments.Count}";
+            imagesCountLb.Text = $"{imagesOffset + 1}-{imagesOffset + imagesPerPage} of {filteredImageAttachments.Count}";
 
             for (int i = 0; i < imagesPerPage; i++)
             {
@@ -617,7 +633,7 @@ namespace Data_Package_Tool
                     loc = new Point(imagesPanel.Controls.Count % imagesPerRow == 0 ? 3 : last.Location.X + last.Size.Width + 6, imagesPanel.Controls.Count % imagesPerRow == 0 ? last.Location.Y + imageSquareSize + 44 : last.Location.Y);
                 }
 
-                var attachment = DataPackage.ImageAttachments[imagesOffset + i];
+                var attachment = filteredImageAttachments[imagesOffset + i];
 
                 var pb = new Attachment(attachment)
                 {
@@ -661,6 +677,22 @@ namespace Data_Package_Tool
                 await LoadImages();
             }
             catch (Exception) { }
+        }
+
+        private async void imagesDateFilter_CheckedChanged(object sender, EventArgs e)
+        {
+            imagesAfterDtp.Enabled = imagesAfterCb.Checked;
+            imagesBeforeDtp.Enabled = imagesBeforeCb.Checked;
+            filteredImageAttachments = null;
+            imagesOffset = 0;
+            if (DataPackage.ImageAttachments.Count > 0) await LoadImages();
+        }
+
+        private async void imagesDateFilter_ValueChanged(object sender, EventArgs e)
+        {
+            filteredImageAttachments = null;
+            imagesOffset = 0;
+            if (DataPackage.ImageAttachments.Count > 0) await LoadImages();
         }
 
         private void discordInstanceSettingsChange(object sender, EventArgs e)


### PR DESCRIPTION
Added ability to filter images by before/after date and time to the Images tab. This could be useful for browsing a large number of historical collections of images, without being limited to the view offered under the Messages tab. 
